### PR TITLE
Added: Handle array in allow & disallow directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generate-robotstxt",
-  "version": "5.0.1",
+  "version": "5.1.1",
   "description": "Awesome generator robots.txt",
   "author": "itgalaxy <development@itgalaxy.company>",
   "contributors": [

--- a/src/__tests__/standalone.js
+++ b/src/__tests__/standalone.js
@@ -22,6 +22,30 @@ test("should `contain one `policy` item with the `Allow` directive", t =>
     t.is(content, "User-agent: Google\nAllow: /\n");
   }));
 
+test("should `contain one `policy` item with two `Allow` directives", t =>
+  generateRobotstxt({
+    policy: [
+      {
+        allow: ["/", "/test"],
+        userAgent: "Google"
+      }
+    ]
+  }).then(content => {
+    t.is(content, "User-agent: Google\nAllow: /\nAllow: /test\n");
+  }));
+
+test("should `contain one `policy` item with two `Disallow` directives", t =>
+  generateRobotstxt({
+    policy: [
+      {
+        disallow: ["/", "/test"],
+        userAgent: "Google"
+      }
+    ]
+  }).then(content => {
+    t.is(content, "User-agent: Google\nDisallow: /\nDisallow: /test\n");
+  }));
+
 test("should contain two `policy` item with the `Allow` directive", t =>
   generateRobotstxt({
     policy: [
@@ -38,6 +62,44 @@ test("should contain two `policy` item with the `Allow` directive", t =>
     t.is(
       content,
       "User-agent: Google\nAllow: /\n\nUser-agent: Yandex\nAllow: /\n"
+    );
+  }));
+
+test("should contain two `policy` items with two `Allow` directives", t =>
+  generateRobotstxt({
+    policy: [
+      {
+        allow: ["/", "/test"],
+        userAgent: "Google"
+      },
+      {
+        allow: ["/", "/test"],
+        userAgent: "Yandex"
+      }
+    ]
+  }).then(content => {
+    t.is(
+      content,
+      "User-agent: Google\nAllow: /\nAllow: /test\n\nUser-agent: Yandex\nAllow: /\nAllow: /test\n"
+    );
+  }));
+
+test("should contain two `policy` items with two `Disallow` directives", t =>
+  generateRobotstxt({
+    policy: [
+      {
+        disallow: ["/", "/test"],
+        userAgent: "Google"
+      },
+      {
+        disallow: ["/", "/test"],
+        userAgent: "Yandex"
+      }
+    ]
+  }).then(content => {
+    t.is(
+      content,
+      "User-agent: Google\nDisallow: /\nDisallow: /test\n\nUser-agent: Yandex\nDisallow: /\nDisallow: /test\n"
     );
   }));
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -37,7 +37,7 @@ function generatePoliceItem(item, index) {
 
   if (item.allow) {
     if (Array.isArray(item.allow)) {
-      item.allow.forEach((allowed) => {
+      item.allow.forEach(allowed => {
         contents += addLine("Allow", allowed);
       });
     } else {
@@ -47,7 +47,7 @@ function generatePoliceItem(item, index) {
 
   if (item.disallow) {
     if (Array.isArray(item.disallow)) {
-      item.disallow.forEach((disallowed) => {
+      item.disallow.forEach(disallowed => {
         contents += addLine("Disallow", disallowed);
       });
     } else {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -36,11 +36,23 @@ function generatePoliceItem(item, index) {
   contents += addLine("User-agent", item.userAgent);
 
   if (item.allow) {
-    contents += addLine("Allow", item.allow);
+    if (Array.isArray(item.allow)) {
+      item.allow.forEach((allowed) => {
+        contents += addLine("Allow", allowed);
+      });
+    } else {
+      contents += addLine("Allow", item.allow);
+    }
   }
 
   if (item.disallow) {
-    contents += addLine("Disallow", item.disallow);
+    if (Array.isArray(item.disallow)) {
+      item.disallow.forEach((disallowed) => {
+        contents += addLine("Disallow", disallowed);
+      });
+    } else {
+      contents += addLine("Disallow", item.disallow);
+    }
   }
 
   if (item.crawlDelay) {


### PR DESCRIPTION
Handles multiple disallows/allows under one policy, eg:

```javascript
{
  policy: [
    {
      userAgent: '*',
      disallow: ['/search/', '/test/']
    },
    {
      userAgent: 'googlebot',
      allow: ['/search/', '/test/']
    }
  ]
};
```