### PR TITLE
update meow 6.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fs-extra": "^9.0.0",
     "ip-regex": "^4.1.0",
     "is-absolute-url": "^3.0.3",
-    "meow": "^6.1.0",
+    "meow": "^6.1.1",
     "resolve-from": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The yargs-parser version in meow 6.1.0 has been flagged for vulnerability.
https://www.npmjs.com/advisories/1500/versions

meow has since updated the deps in 6.1.1
https://github.com/sindresorhus/meow/commit/f85b546eda6a6fc7382e7ccf874465a56033735c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

